### PR TITLE
Added Link Time Optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,10 @@ edition = "2021"
 
 [dependencies]
 ratatui = "0.28.1"
+
+[profile.release]
+lto = true
+
+[profile.release-thin-lto]
+inherits = "release"
+lto = "thin"


### PR DESCRIPTION
This pull request implements Link Time Optimization (LTO) for release builds as suggested in #1. 

I've added a Fat LTO to the default release profile as well as implemented a "release-thin-lto" for user that opt in with Thin LTO.

This change is made to reduce binary size and improve performance, without affecting regular development builds

To build with Fat LTO:

```bash
cargo build --release
```

To build with Thin LTO:
```bash
cargo build --profile release-thin-lto
```